### PR TITLE
Fix measurement dict handling

### DIFF
--- a/aufmass_view.py
+++ b/aufmass_view.py
@@ -102,8 +102,8 @@ class AufmassView(QWidget):
             if existing_measurement:
                 # Update existing measurement
                 measurement_data['id'] = existing_measurement.id
-                success = self._aufmass_service.update_measurement(measurement_data)
-                if not success:
+                measurement_id = self._aufmass_service.update_measurement(measurement_data)
+                if measurement_id == 0:
                     logger.error(f"Failed to update measurement for position {self._current_position_id}")
             else:
                 # Create new measurement
@@ -173,7 +173,7 @@ class AufmassView(QWidget):
             
         try:
             # Update the measurement
-            self._aufmass_service.update_measurement(measurement_data)
+            measurement_id = self._aufmass_service.update_measurement(measurement_data)
             
             # Reload measurements
             self._load_measurements()

--- a/aufmass_viewmodel.py
+++ b/aufmass_viewmodel.py
@@ -121,9 +121,9 @@ class AufmassViewModel(QObject):
                 measurement_data['position_id'] = self._current_position_id
                 
             # Update the measurement
-            success = self._aufmass_service.update_measurement(measurement_data)
-            
-            if not success:
+            measurement_id = self._aufmass_service.update_measurement(measurement_data)
+
+            if measurement_id == 0:
                 raise ValueError(f"Failed to update measurement {measurement_data.get('id')}")
             
             # Reload measurements

--- a/services/aufmass_service.py
+++ b/services/aufmass_service.py
@@ -6,6 +6,7 @@ if project_root not in sys.path:
     sys.path.insert(0, project_root)
 from typing import List, Dict, Any, Optional
 from utils.logger import get_logger
+from models.aufmass_item import AufmassItem
 
 logger = get_logger(__name__)
 
@@ -96,14 +97,15 @@ class AufmassService:
             ID of the created measurement
         """
         try:
-            measurement_id = self.data_service.save_measurement(measurement_data)
+            measurement = AufmassItem.from_dict(measurement_data)
+            measurement_id = self.data_service.save_measurement(measurement)
             logger.info(f"Measurement created with ID: {measurement_id}")
             return measurement_id
         except Exception as e:
             logger.error(f"Error creating measurement: {e}")
             return 0
     
-    def update_measurement(self, measurement_data: Dict[str, Any]) -> bool:
+    def update_measurement(self, measurement_data: Dict[str, Any]) -> int:
         """
         Update an existing measurement.
         
@@ -111,15 +113,16 @@ class AufmassService:
             measurement_data: Measurement data to update
             
         Returns:
-            True if successful, False otherwise
+            ID of the updated measurement or 0 on failure
         """
         try:
-            self.data_service.save_measurement(measurement_data)
-            logger.info(f"Measurement updated: {measurement_data.get('id')}")
-            return True
+            measurement = AufmassItem.from_dict(measurement_data)
+            measurement_id = self.data_service.save_measurement(measurement)
+            logger.info(f"Measurement updated: {measurement_id}")
+            return measurement_id
         except Exception as e:
             logger.error(f"Error updating measurement: {e}")
-            return False
+            return 0
     
     def delete_measurement(self, measurement_id: int) -> bool:
         """

--- a/services/data_service.py
+++ b/services/data_service.py
@@ -726,20 +726,22 @@ class DataService:
             # Parse photos from JSON
             photos = json.loads(row['photos']) if row['photos'] else []
             
-            measurement = AufmassItem(
-                id=row['id'],
-                position_id=row['position_id'],
-                project_id=row['project_id'],
-                inner_width=row['inner_width'],
-                inner_height=row['inner_height'],
-                outer_width=row['outer_width'],
-                outer_height=row['outer_height'],
-                diagonal=row['diagonal'],
-                special_notes=row['special_notes'],
-                photos=photos,
-                created_at=datetime.fromisoformat(row['created_at']),
-                updated_at=datetime.fromisoformat(row['updated_at'])
-            )
+            data_dict = {
+                'id': row['id'],
+                'position_id': row['position_id'],
+                'project_id': row['project_id'],
+                'inner_width': row['inner_width'],
+                'inner_height': row['inner_height'],
+                'outer_width': row['outer_width'],
+                'outer_height': row['outer_height'],
+                'diagonal': row['diagonal'],
+                'special_notes': row['special_notes'],
+                'photos': photos,
+                'created_at': datetime.fromisoformat(row['created_at']),
+                'updated_at': datetime.fromisoformat(row['updated_at'])
+            }
+
+            measurement = AufmassItem.from_dict(data_dict)
             
             return measurement
         

--- a/tests/test_aufmass_service.py
+++ b/tests/test_aufmass_service.py
@@ -1,0 +1,54 @@
+import os
+import sys
+import tempfile
+import pytest
+
+project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+from services.aufmass_service import AufmassService
+from services.data_service import DataService
+
+
+@pytest.fixture
+def aufmass_service(tmp_path):
+    db_path = tmp_path / "aufmass_test.db"
+    data_service = DataService(str(db_path))
+    service = AufmassService(data_service=data_service)
+    yield service
+    data_service.shutdown()
+
+
+def test_create_measurement_from_dict(aufmass_service):
+    measurement_data = {
+        "position_id": "pos1",
+        "project_id": 1,
+        "inner_width": 1200,
+        "inner_height": 1000,
+    }
+
+    measurement_id = aufmass_service.create_measurement(measurement_data)
+    assert isinstance(measurement_id, int) and measurement_id > 0
+
+    measurement = aufmass_service.data_service.get_measurement("pos1")
+    assert measurement is not None
+    assert measurement.position_id == "pos1"
+
+
+def test_update_measurement_from_dict(aufmass_service):
+    measurement_data = {
+        "position_id": "pos2",
+        "project_id": 1,
+        "inner_width": 1000,
+        "inner_height": 800,
+    }
+    measurement_id = aufmass_service.create_measurement(measurement_data)
+
+    measurement_data.update({"id": measurement_id, "inner_width": 1100})
+    updated_id = aufmass_service.update_measurement(measurement_data)
+    assert updated_id == measurement_id
+
+    measurement = aufmass_service.data_service.get_measurement("pos2")
+    assert measurement is not None
+    assert measurement.inner_width == 1100

--- a/viewmodels/aufmass_viewmodel.py
+++ b/viewmodels/aufmass_viewmodel.py
@@ -121,9 +121,9 @@ class AufmassViewModel(QObject):
                 measurement_data['position_id'] = self._current_position_id
                 
             # Update the measurement
-            success = self._aufmass_service.update_measurement(measurement_data)
-            
-            if not success:
+            measurement_id = self._aufmass_service.update_measurement(measurement_data)
+
+            if measurement_id == 0:
                 raise ValueError(f"Failed to update measurement {measurement_data.get('id')}")
             
             # Reload measurements

--- a/views/aufmass_view.py
+++ b/views/aufmass_view.py
@@ -102,8 +102,8 @@ class AufmassView(QWidget):
             if existing_measurement:
                 # Update existing measurement
                 measurement_data['id'] = existing_measurement.id
-                success = self._aufmass_service.update_measurement(measurement_data)
-                if not success:
+                measurement_id = self._aufmass_service.update_measurement(measurement_data)
+                if measurement_id == 0:
                     logger.error(f"Failed to update measurement for position {self._current_position_id}")
             else:
                 # Create new measurement
@@ -173,7 +173,7 @@ class AufmassView(QWidget):
             
         try:
             # Update the measurement
-            self._aufmass_service.update_measurement(measurement_data)
+            measurement_id = self._aufmass_service.update_measurement(measurement_data)
             
             # Reload measurements
             self._load_measurements()


### PR DESCRIPTION
## Summary
- convert measurement dicts to `AufmassItem` before saving
- return measurement id from `update_measurement`
- adjust view layers for new return type
- fix `AufmassItem.from_dict` to bypass dataclass init
- use the new helper in `DataService.get_measurement`
- add tests for saving measurements from dictionaries

## Testing
- `pytest tests/test_aufmass_service.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685447bb19b8832f8ed7c7d0af1a519d