### PR TITLE
Ensure designer_requested emits string

### DIFF
--- a/dynamic_aufmass_ui.py
+++ b/dynamic_aufmass_ui.py
@@ -293,8 +293,8 @@ class DynamicAufmassUI(QWidget):
         # Calculate final values
         final_data = self.schema_service.calculate_derived_values(self.measurement_data)
         
-        # Emit signal to open designer
-        self.designer_requested.emit(self.current_position_id, final_data)
+        # Emit signal to open designer with position ID as string
+        self.designer_requested.emit(str(self.current_position_id), final_data)
         
     def set_position(self, position_id: str, position_info: Optional[Dict[str, Any]] = None):
         """Set the current position and update UI."""

--- a/tests/test_dynamic_aufmass_ui.py
+++ b/tests/test_dynamic_aufmass_ui.py
@@ -1,0 +1,40 @@
+import os
+import sys
+
+project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+import pytest
+from PyQt6.QtWidgets import QApplication
+
+from ui.dynamic_aufmass_ui import DynamicAufmassUI
+
+@pytest.fixture
+def qapp():
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+def test_designer_requested_emits_string(qapp):
+    ui = DynamicAufmassUI()
+    ui.current_position_id = 123  # intentionally int
+    ui.measurement_data = {
+        'inner_width': 1200,
+        'inner_height': 1000,
+        'outer_width': 1250,
+        'outer_height': 1050
+    }
+
+    captured = {}
+    def handler(pos_id, data):
+        captured['pos_id'] = pos_id
+        captured['data'] = data
+
+    ui.designer_requested.connect(handler)
+    ui._open_designer()
+
+    assert captured['pos_id'] == '123'
+    assert isinstance(captured['pos_id'], str)
+

--- a/ui/dynamic_aufmass_ui.py
+++ b/ui/dynamic_aufmass_ui.py
@@ -293,8 +293,8 @@ class DynamicAufmassUI(QWidget):
         # Calculate final values
         final_data = self.schema_service.calculate_derived_values(self.measurement_data)
         
-        # Emit signal to open designer
-        self.designer_requested.emit(self.current_position_id, final_data)
+        # Emit signal to open designer with position ID as string
+        self.designer_requested.emit(str(self.current_position_id), final_data)
         
     def set_position(self, position_id: str, position_info: Optional[Dict[str, Any]] = None):
         """Set the current position and update UI."""


### PR DESCRIPTION
## Summary
- emit `designer_requested` signal with `str()` position ID in UI
- add regression test for signal type

## Testing
- `pytest tests/test_dynamic_aufmass_ui.py::test_designer_requested_emits_string -q`

------
https://chatgpt.com/codex/tasks/task_e_685449fffc4c832fb45a61fcb87c4a33